### PR TITLE
Ensure templates render with base layout

### DIFF
--- a/internal/views/templates/error.gohtml
+++ b/internal/views/templates/error.gohtml
@@ -1,3 +1,5 @@
+{{template "base" .}}
+
 {{define "body"}}
 <div class="card">
   <h1>Error {{.Status}}</h1>

--- a/internal/views/templates/home.gohtml
+++ b/internal/views/templates/home.gohtml
@@ -1,3 +1,5 @@
+{{template "base" .}}
+
 {{define "body"}}
 <div class="card">
   <h1>Recent Posts</h1>

--- a/internal/views/templates/login.gohtml
+++ b/internal/views/templates/login.gohtml
@@ -1,3 +1,5 @@
+{{template "base" .}}
+
 {{define "body"}}
 <div class="card">
   <h1>Login</h1>

--- a/internal/views/templates/new_post.gohtml
+++ b/internal/views/templates/new_post.gohtml
@@ -1,3 +1,5 @@
+{{template "base" .}}
+
 {{define "body"}}
 <div class="card">
   <h1>New Post</h1>

--- a/internal/views/templates/post_detail.gohtml
+++ b/internal/views/templates/post_detail.gohtml
@@ -1,3 +1,5 @@
+{{template "base" .}}
+
 {{define "body"}}
 <article class="card">
   <header>

--- a/internal/views/templates/register.gohtml
+++ b/internal/views/templates/register.gohtml
@@ -1,3 +1,5 @@
+{{template "base" .}}
+
 {{define "body"}}
 <div class="card">
   <h1>Create an Account</h1>


### PR DESCRIPTION
## Summary
- Use base template in every page template to avoid layout parsing errors
- Render pages by defining body content within base layout

## Testing
- `go test ./internal/tests -run TestHashAndCheckPassword -v` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a26f21e5508333a5c55a4240c30415