### PR TITLE
Refactor server structure and add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Simple Makefile for the forum project
+
+.PHONY: build run
+
+build:
+	go build ./...
+
+run:
+	go run ./cmd/server

--- a/cmd/server/middleware.go
+++ b/cmd/server/middleware.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"forum-mvp/internal/app"
+)
+
+/*
+logRequest prints the method, path and how long the handler took.
+It's handy while developing to see what's going on.
+*/
+func logRequest(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		fmt.Printf("%s %s %s\n", r.Method, r.URL.Path, time.Since(start))
+	})
+}
+
+/*
+withCustomErrors wraps the default mux and provides friendly 404
+and 500 pages when things go wrong.
+*/
+func withCustomErrors(next *http.ServeMux, app *app.App) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.Header().Set("Cache-Control", "no-store")
+				w.WriteHeader(http.StatusInternalServerError)
+				if tpl, ok := app.Templates["500.html"]; ok {
+					tpl.ExecuteTemplate(w, "500.html", appTemplateData(r, app))
+				} else {
+					http.Error(w, "Internal Server Error", 500)
+				}
+			}
+		}()
+
+		rw := &responseWriter{ResponseWriter: w, statusCode: 200}
+		next.ServeHTTP(rw, r)
+
+		if rw.statusCode == http.StatusNotFound {
+			if tpl, ok := app.Templates["404.html"]; ok {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.Header().Set("Cache-Control", "no-store")
+				tpl.ExecuteTemplate(w, "404.html", appTemplateData(r, app))
+			} else {
+				http.NotFound(w, r)
+			}
+		}
+	})
+}
+
+/*
+responseWriter records the status code so we can check it
+after the handler runs.
+*/
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+/*
+appTemplateData builds the common template data including
+the logged-in user and category list.
+*/
+func appTemplateData(r *http.Request, app *app.App) map[string]any {
+	uid, uname, logged := app.CurrentUser(r)
+	cats, _ := app.AllCategories()
+	return map[string]any{
+		"LoggedIn":   logged,
+		"UserID":     uid,
+		"Username":   uname,
+		"Categories": cats,
+	}
+}

--- a/cmd/server/templates.go
+++ b/cmd/server/templates.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"html/template"
+	"path/filepath"
+)
+
+/*
+loadTemplates walks the directory and parses every template
+alongside the shared layout. It returns a map keyed by
+filename so handlers can pick the right template.
+*/
+func loadTemplates(dir string) (map[string]*template.Template, error) {
+	layout := filepath.Join(dir, "layout.html")
+	pages, err := filepath.Glob(filepath.Join(dir, "*.html"))
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]*template.Template)
+	for _, page := range pages {
+		if filepath.Base(page) == "layout.html" {
+			continue
+		}
+		t, err := template.ParseFiles(layout, page)
+		if err != nil {
+			return nil, err
+		}
+		m[filepath.Base(page)] = t
+	}
+	return m, nil
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,18 +2,12 @@ package app
 
 import (
 	"database/sql"
-	"errors"
 	"html/template"
 	"net/http"
-	"strconv"
-	"strings"
 	"time"
-
-	"github.com/google/uuid"
-	_ "github.com/mattn/go-sqlite3"
-	"golang.org/x/crypto/bcrypt"
 )
 
+// App holds core services shared across handlers.
 type App struct {
 	DB         *sql.DB
 	Templates  map[string]*template.Template
@@ -21,7 +15,10 @@ type App struct {
 	SessionTTL time.Duration
 }
 
-// Utilities
+/*
+CurrentUser checks the session cookie and returns the user id and
+username when a valid session is found.
+*/
 func (a *App) CurrentUser(r *http.Request) (id int64, username string, ok bool) {
 	c, err := r.Cookie(a.CookieName)
 	if err != nil {
@@ -44,6 +41,9 @@ func (a *App) CurrentUser(r *http.Request) (id int64, username string, ok bool) 
 	return userID, username, true
 }
 
+/*
+RequireAuth ensures the user is logged in before calling the next handler.
+*/
 func (a *App) RequireAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if _, _, ok := a.CurrentUser(r); !ok {
@@ -54,9 +54,12 @@ func (a *App) RequireAuth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+/*
+render writes common headers and executes the named template.
+*/
 func (a *App) render(w http.ResponseWriter, name string, data any) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	// Helpful in dev to avoid stale pages:
+	/* Helpful in dev to avoid stale pages */
 	w.Header().Set("Cache-Control", "no-store")
 	tpl, ok := a.Templates[name]
 	if !ok {
@@ -65,404 +68,5 @@ func (a *App) render(w http.ResponseWriter, name string, data any) {
 	}
 	if err := tpl.ExecuteTemplate(w, name, data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-}
-
-// Handlers
-func (a *App) HandleIndex(w http.ResponseWriter, r *http.Request) {
-	// Filters: category, mine=posts, liked
-	q := `SELECT p.id, p.title, p.body, p.created_at, u.username,
-                 (SELECT COUNT(*) FROM likes l WHERE l.target_type='post' AND l.target_id=p.id AND l.value=1) AS likes,
-                 (SELECT COUNT(*) FROM likes l WHERE l.target_type='post' AND l.target_id=p.id AND l.value=-1) AS dislikes
-          FROM posts p
-          JOIN users u ON u.id = p.user_id
-          WHERE 1=1`
-	args := []any{}
-
-	if cat := r.URL.Query().Get("category"); cat != "" {
-		q += ` AND EXISTS (SELECT 1 FROM post_categories pc JOIN categories c ON c.id=pc.category_id WHERE pc.post_id=p.id AND c.name=?)`
-		args = append(args, cat)
-	}
-
-	if r.URL.Query().Get("mine") == "1" {
-		if uid, _, ok := a.CurrentUser(r); ok {
-			q += ` AND p.user_id = ?`
-			args = append(args, uid)
-		} else {
-			http.Redirect(w, r, "/login", http.StatusSeeOther)
-			return
-		}
-	}
-
-	if r.URL.Query().Get("liked") == "1" {
-		if uid, _, ok := a.CurrentUser(r); ok {
-			q += ` AND p.id IN (SELECT target_id FROM likes WHERE target_type='post' AND user_id=? AND value=1)`
-			args = append(args, uid)
-		} else {
-			http.Redirect(w, r, "/login", http.StatusSeeOther)
-			return
-		}
-	}
-
-	q += ` ORDER BY p.created_at DESC LIMIT 50`
-
-	rows, err := a.DB.Query(q, args...)
-	if err != nil {
-		http.Error(w, err.Error(), 500)
-		return
-	}
-	defer rows.Close()
-
-	type Row struct {
-		ID                    int64
-		Title, Body, Username string
-		CreatedAt             string
-		Likes, Dislikes       int
-	}
-	var posts []Row
-	for rows.Next() {
-		var rrow Row
-		var ts time.Time
-		if err := rows.Scan(&rrow.ID, &rrow.Title, &rrow.Body, &ts, &rrow.Username, &rrow.Likes, &rrow.Dislikes); err != nil {
-			http.Error(w, err.Error(), 500)
-			return
-		}
-		rrow.CreatedAt = ts.Format("2006-01-02 15:04")
-		posts = append(posts, rrow)
-	}
-
-	// Fetch categories for sidebar/filter
-	cats, _ := a.AllCategories()
-
-	uid, uname, logged := a.CurrentUser(r)
-	a.render(w, "index.html", map[string]any{
-		"View":       "index",
-		"Posts":      posts,
-		"Categories": cats,
-		"LoggedIn":   logged,
-		"UserID":     uid,
-		"Username":   uname,
-		"Filter": map[string]string{
-			"category": r.URL.Query().Get("category"),
-			"mine":     r.URL.Query().Get("mine"),
-			"liked":    r.URL.Query().Get("liked"),
-		},
-	})
-}
-
-func (a *App) AllCategories() ([]string, error) {
-	rows, err := a.DB.Query(`SELECT name FROM categories ORDER BY name`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var out []string
-	for rows.Next() {
-		var n string
-		rows.Scan(&n)
-		out = append(out, n)
-	}
-	return out, nil
-}
-
-func (a *App) HandleRegister(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		a.render(w, "register.html", map[string]any{"View": "register"})
-	case http.MethodPost:
-		email := r.FormValue("email")
-		username := r.FormValue("username")
-		pass := r.FormValue("password")
-		if email == "" || username == "" || pass == "" {
-			http.Error(w, "missing fields", http.StatusBadRequest)
-			return
-		}
-		hash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-			return
-		}
-		_, err = a.DB.Exec(`INSERT INTO users(email, username, password_hash) VALUES(?,?,?)`, email, username, string(hash))
-		if err != nil {
-			if isUniqueErr(err) {
-				// http.Error(w, "email or username already taken", http.StatusConflict)
-				w.WriteHeader(http.StatusUnauthorized)
-				a.render(w, "register.html", map[string]any{
-					"View":  "register",
-					"Error": "email or username already taken",
-				})
-				return
-			}
-			http.Error(w, err.Error(), 500)
-			return
-		}
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
-	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-	}
-}
-
-func isUniqueErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	// Simple detection based on SQLite error string for MVP
-	return strings.Contains(err.Error(), "UNIQUE constraint failed")
-}
-
-func (a *App) HandleLogin(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		a.render(w, "login.html", map[string]any{"View": "login"})
-		return
-
-	case http.MethodPost:
-		email := r.FormValue("email")
-		pass := r.FormValue("password")
-
-		var (
-			id       int64
-			hash     string
-			username string
-		)
-		err := a.DB.QueryRow(`SELECT id, username, password_hash FROM users WHERE email=?`, email).
-			Scan(&id, &username, &hash)
-		if err != nil || bcrypt.CompareHashAndPassword([]byte(hash), []byte(pass)) != nil {
-			w.WriteHeader(http.StatusUnauthorized)
-			a.render(w, "login.html", map[string]any{
-				"View":  "login",
-				"Error": "invalid credentials",
-			})
-			return
-		}
-
-		// Start a TX so we don't leave the user with zero sessions if insert fails.
-		tx, err := a.DB.Begin()
-		if err != nil {
-			http.Error(w, "failed to start transaction", http.StatusInternalServerError)
-			return
-		}
-		defer func() {
-			_ = tx.Rollback() // safe no-op if already committed
-		}()
-
-		// Invalidate any previous sessions for this user.
-		if _, err = tx.Exec(`DELETE FROM sessions WHERE user_id=?`, id); err != nil {
-			http.Error(w, "failed to clear old sessions", http.StatusInternalServerError)
-			return
-		}
-
-		// Create a brand new session ID.
-		sid := uuid.NewString()
-		expiresAt := time.Now().Add(a.SessionTTL)
-
-		if _, err = tx.Exec(
-			`INSERT INTO sessions(id, user_id, expires_at) VALUES(?,?,?)`,
-			sid, id, expiresAt,
-		); err != nil {
-			http.Error(w, "failed to create session", http.StatusInternalServerError)
-			return
-		}
-
-		if err = tx.Commit(); err != nil {
-			http.Error(w, "failed to finalize login", http.StatusInternalServerError)
-			return
-		}
-
-		// Set cookie (consider adding Secure: true in production over HTTPS).
-		http.SetCookie(w, &http.Cookie{
-			Name:     a.CookieName,
-			Value:    sid,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			Expires:  expiresAt,
-			// Secure: true, // uncomment when behind HTTPS
-		})
-
-		http.Redirect(w, r, "/", http.StatusSeeOther)
-		return
-
-	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-}
-
-func (a *App) HandleLogout(w http.ResponseWriter, r *http.Request) {
-	c, err := r.Cookie(a.CookieName)
-	if err == nil {
-		a.DB.Exec(`DELETE FROM sessions WHERE id=?`, c.Value)
-	}
-	http.SetCookie(w, &http.Cookie{Name: a.CookieName, Value: "", Path: "/", Expires: time.Unix(0, 0), MaxAge: -1})
-	http.Redirect(w, r, "/", http.StatusSeeOther)
-}
-
-func (a *App) HandleNewPost(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		cats, _ := a.AllCategories()
-		a.render(w, "post_new.html", map[string]any{"View": "post_new", "Categories": cats})
-	case http.MethodPost:
-		uid, _, ok := a.CurrentUser(r)
-		if !ok {
-			http.Redirect(w, r, "/login", http.StatusSeeOther)
-			return
-		}
-		title := r.FormValue("title")
-		body := r.FormValue("body")
-		if title == "" || body == "" {
-			http.Error(w, "title/body required", 400)
-			return
-		}
-		res, err := a.DB.Exec(`INSERT INTO posts(user_id, title, body) VALUES(?,?,?)`, uid, title, body)
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-			return
-		}
-		pid, _ := res.LastInsertId()
-		if err := r.ParseForm(); err == nil {
-			seen := map[string]bool{}
-			for _, cname := range r.Form["category"] {
-				for _, part := range strings.Split(cname, ",") {
-					c := strings.TrimSpace(part)
-					if c == "" || seen[c] {
-						continue
-					}
-					seen[c] = true
-					var cid int64
-					err := a.DB.QueryRow(`SELECT id FROM categories WHERE name=?`, c).Scan(&cid)
-					if errors.Is(err, sql.ErrNoRows) {
-						res, err := a.DB.Exec(`INSERT INTO categories(name) VALUES(?)`, c)
-						if err == nil {
-							cid, _ = res.LastInsertId()
-						}
-					}
-					if cid != 0 {
-						a.DB.Exec(`INSERT OR IGNORE INTO post_categories(post_id, category_id) VALUES(?,?)`, pid, cid)
-					}
-				}
-			}
-		}
-		http.Redirect(w, r, "/post?id="+strconv.FormatInt(pid, 10), http.StatusSeeOther)
-	default:
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-	}
-}
-
-func (a *App) HandleShowPost(w http.ResponseWriter, r *http.Request) {
-	id := r.URL.Query().Get("id")
-	type Post struct {
-		ID                    int64
-		Title, Body, Username string
-		CreatedAt             string
-		Likes, Dislikes       int
-		Categories            []string
-	}
-	var p Post
-	var ts time.Time
-	err := a.DB.QueryRow(`SELECT p.id, p.title, p.body, p.created_at, u.username,
-        (SELECT COUNT(*) FROM likes l WHERE l.target_type='post' AND l.target_id=p.id AND l.value=1) AS likes,
-        (SELECT COUNT(*) FROM likes l WHERE l.target_type='post' AND l.target_id=p.id AND l.value=-1) AS dislikes
-        FROM posts p
-        JOIN users u ON u.id=p.user_id
-        WHERE p.id=?`, id).Scan(&p.ID, &p.Title, &p.Body, &ts, &p.Username, &p.Likes, &p.Dislikes)
-	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-	p.CreatedAt = ts.Format("2006-01-02 15:04")
-	// categories
-	rows, _ := a.DB.Query(`SELECT c.name FROM categories c JOIN post_categories pc ON pc.category_id=c.id WHERE pc.post_id=? ORDER BY c.name`, id)
-	defer rows.Close()
-	for rows.Next() {
-		var n string
-		rows.Scan(&n)
-		p.Categories = append(p.Categories, n)
-	}
-
-	// comments
-	crows, err := a.DB.Query(`SELECT c.id, c.body, c.created_at, u.username,
-        (SELECT COUNT(*) FROM likes l WHERE l.target_type='comment' AND l.target_id=c.id AND l.value=1) AS likes,
-        (SELECT COUNT(*) FROM likes l WHERE l.target_type='comment' AND l.target_id=c.id AND l.value=-1) AS dislikes
-        FROM comments c
-        JOIN users u ON u.id=c.user_id
-        WHERE c.post_id=?
-        ORDER BY c.created_at ASC`, id)
-	if err != nil {
-		http.Error(w, err.Error(), 500)
-		return
-	}
-	type Comment struct {
-		ID                        int64
-		Body, Username, CreatedAt string
-		Likes, Dislikes           int
-	}
-	var comments []Comment
-	for crows.Next() {
-		var cmt Comment
-		var t time.Time
-		if err := crows.Scan(&cmt.ID, &cmt.Body, &t, &cmt.Username, &cmt.Likes, &cmt.Dislikes); err == nil {
-			cmt.CreatedAt = t.Format("2006-01-02 15:04")
-			comments = append(comments, cmt)
-		}
-	}
-	uid, uname, logged := a.CurrentUser(r)
-	a.render(w, "post_show.html", map[string]any{
-		"View":     "post_show",
-		"Post":     p,
-		"Comments": comments,
-		"LoggedIn": logged,
-		"UserID":   uid,
-		"Username": uname,
-	})
-}
-
-func (a *App) HandleNewComment(w http.ResponseWriter, r *http.Request) {
-	uid, _, ok := a.CurrentUser(r)
-	if !ok {
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
-		return
-	}
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	postID := r.FormValue("post_id")
-	body := r.FormValue("body")
-	if body == "" {
-		http.Error(w, "empty comment", 400)
-		return
-	}
-	if _, err := a.DB.Exec(`INSERT INTO comments(post_id, user_id, body) VALUES(?,?,?)`, postID, uid, body); err != nil {
-		http.Error(w, err.Error(), 500)
-		return
-	}
-	http.Redirect(w, r, "/post?id="+postID, http.StatusSeeOther)
-}
-
-func (a *App) HandleLike(w http.ResponseWriter, r *http.Request) {
-	uid, _, ok := a.CurrentUser(r)
-	if !ok {
-		http.Redirect(w, r, "/login", http.StatusSeeOther)
-		return
-	}
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	typ := r.FormValue("type") // post/comment
-	tid := r.FormValue("id")
-	val := r.FormValue("value") // 1 or -1
-	_, err := a.DB.Exec(`INSERT INTO likes(user_id, target_type, target_id, value) VALUES(?,?,?,?)
-                         ON CONFLICT(user_id, target_type, target_id) DO UPDATE SET value=excluded.value`, uid, typ, tid, val)
-	if err != nil {
-		http.Error(w, err.Error(), 500)
-		return
-	}
-	if typ == "post" {
-		http.Redirect(w, r, "/post?id="+tid, http.StatusSeeOther)
-	} else {
-		http.Redirect(w, r, r.Referer(), http.StatusSeeOther)
 	}
 }

--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+)
+
+/*
+HandleRegister shows the registration form or creates a new user when data is posted.
+*/
+func (a *App) HandleRegister(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		a.render(w, "register.html", map[string]any{"View": "register"})
+	case http.MethodPost:
+		email := r.FormValue("email")
+		username := r.FormValue("username")
+		pass := r.FormValue("password")
+		if email == "" || username == "" || pass == "" {
+			http.Error(w, "missing fields", http.StatusBadRequest)
+			return
+		}
+		hash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		_, err = a.DB.Exec(`INSERT INTO users(email, username, password_hash) VALUES(?,?,?)`, email, username, string(hash))
+		if err != nil {
+			if isUniqueErr(err) {
+				w.WriteHeader(http.StatusUnauthorized)
+				a.render(w, "register.html", map[string]any{
+					"View":  "register",
+					"Error": "email or username already taken",
+				})
+				return
+			}
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+/*
+isUniqueErr looks for the SQLite unique constraint error message.
+*/
+func isUniqueErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "UNIQUE constraint failed")
+}
+
+/*
+HandleLogin verifies credentials and starts a new session for the user.
+*/
+func (a *App) HandleLogin(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		a.render(w, "login.html", map[string]any{"View": "login"})
+		return
+
+	case http.MethodPost:
+		email := r.FormValue("email")
+		pass := r.FormValue("password")
+
+		var (
+			id       int64
+			hash     string
+			username string
+		)
+		err := a.DB.QueryRow(`SELECT id, username, password_hash FROM users WHERE email=?`, email).
+			Scan(&id, &username, &hash)
+		if err != nil || bcrypt.CompareHashAndPassword([]byte(hash), []byte(pass)) != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			a.render(w, "login.html", map[string]any{
+				"View":  "login",
+				"Error": "invalid credentials",
+			})
+			return
+		}
+
+		tx, err := a.DB.Begin()
+		if err != nil {
+			http.Error(w, "failed to start transaction", http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		if _, err = tx.Exec(`DELETE FROM sessions WHERE user_id=?`, id); err != nil {
+			http.Error(w, "failed to clear old sessions", http.StatusInternalServerError)
+			return
+		}
+
+		sid := uuid.NewString()
+		expiresAt := time.Now().Add(a.SessionTTL)
+
+		if _, err = tx.Exec(`INSERT INTO sessions(id, user_id, expires_at) VALUES(?,?,?)`, sid, id, expiresAt); err != nil {
+			http.Error(w, "failed to create session", http.StatusInternalServerError)
+			return
+		}
+
+		if err = tx.Commit(); err != nil {
+			http.Error(w, "failed to finalize login", http.StatusInternalServerError)
+			return
+		}
+
+		http.SetCookie(w, &http.Cookie{
+			Name:     a.CookieName,
+			Value:    sid,
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Expires:  expiresAt,
+		})
+
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+		return
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+/*
+HandleLogout clears the session cookie and removes it from the database.
+*/
+func (a *App) HandleLogout(w http.ResponseWriter, r *http.Request) {
+	c, err := r.Cookie(a.CookieName)
+	if err == nil {
+		a.DB.Exec(`DELETE FROM sessions WHERE id=?`, c.Value)
+	}
+	http.SetCookie(w, &http.Cookie{Name: a.CookieName, Value: "", Path: "/", Expires: time.Unix(0, 0), MaxAge: -1})
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}

--- a/internal/app/categories.go
+++ b/internal/app/categories.go
@@ -1,0 +1,19 @@
+package app
+
+/*
+AllCategories retrieves the list of category names ordered alphabetically.
+*/
+func (a *App) AllCategories() ([]string, error) {
+	rows, err := a.DB.Query(`SELECT name FROM categories ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var n string
+		rows.Scan(&n)
+		out = append(out, n)
+	}
+	return out, nil
+}

--- a/internal/app/index.go
+++ b/internal/app/index.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"net/http"
+	"time"
+)
+
+/*
+HandleIndex renders the home page with recent posts and filter controls.
+*/
+func (a *App) HandleIndex(w http.ResponseWriter, r *http.Request) {
+	q := `SELECT p.id, p.title, p.body, p.created_at, u.username,
+                 (SELECT COUNT(*) FROM likes l WHERE l.target_type='post' AND l.target_id=p.id AND l.value=1) AS likes,
+                 (SELECT COUNT(*) FROM likes l WHERE l.target_type='post' AND l.target_id=p.id AND l.value=-1) AS dislikes
+          FROM posts p
+          JOIN users u ON u.id = p.user_id
+          WHERE 1=1`
+	args := []any{}
+
+	if cat := r.URL.Query().Get("category"); cat != "" {
+		q += ` AND EXISTS (SELECT 1 FROM post_categories pc JOIN categories c ON c.id=pc.category_id WHERE pc.post_id=p.id AND c.name=?)`
+		args = append(args, cat)
+	}
+
+	if r.URL.Query().Get("mine") == "1" {
+		if uid, _, ok := a.CurrentUser(r); ok {
+			q += ` AND p.user_id = ?`
+			args = append(args, uid)
+		} else {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+	}
+
+	if r.URL.Query().Get("liked") == "1" {
+		if uid, _, ok := a.CurrentUser(r); ok {
+			q += ` AND p.id IN (SELECT target_id FROM likes WHERE target_type='post' AND user_id=? AND value=1)`
+			args = append(args, uid)
+		} else {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+	}
+
+	q += ` ORDER BY p.created_at DESC LIMIT 50`
+
+	rows, err := a.DB.Query(q, args...)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	defer rows.Close()
+
+	type Row struct {
+		ID                    int64
+		Title, Body, Username string
+		CreatedAt             string
+		Likes, Dislikes       int
+	}
+	var posts []Row
+	for rows.Next() {
+		var rrow Row
+		var ts time.Time
+		if err := rows.Scan(&rrow.ID, &rrow.Title, &rrow.Body, &ts, &rrow.Username, &rrow.Likes, &rrow.Dislikes); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		rrow.CreatedAt = ts.Format("2006-01-02 15:04")
+		posts = append(posts, rrow)
+	}
+
+	cats, _ := a.AllCategories()
+
+	uid, uname, logged := a.CurrentUser(r)
+	a.render(w, "index.html", map[string]any{
+		"View":       "index",
+		"Posts":      posts,
+		"Categories": cats,
+		"LoggedIn":   logged,
+		"UserID":     uid,
+		"Username":   uname,
+		"Filter": map[string]string{
+			"category": r.URL.Query().Get("category"),
+			"mine":     r.URL.Query().Get("mine"),
+			"liked":    r.URL.Query().Get("liked"),
+		},
+	})
+}

--- a/internal/app/posts.go
+++ b/internal/app/posts.go
@@ -1,0 +1,189 @@
+package app
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+/*
+HandleNewPost creates a new post for the logged-in user.
+*/
+func (a *App) HandleNewPost(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		cats, _ := a.AllCategories()
+		a.render(w, "post_new.html", map[string]any{"View": "post_new", "Categories": cats})
+	case http.MethodPost:
+		uid, _, ok := a.CurrentUser(r)
+		if !ok {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+		title := r.FormValue("title")
+		body := r.FormValue("body")
+		if title == "" || body == "" {
+			http.Error(w, "title/body required", 400)
+			return
+		}
+		res, err := a.DB.Exec(`INSERT INTO posts(user_id, title, body) VALUES(?,?,?)`, uid, title, body)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		pid, _ := res.LastInsertId()
+		if err := r.ParseForm(); err == nil {
+			seen := map[string]bool{}
+			for _, cname := range r.Form["category"] {
+				for _, part := range strings.Split(cname, ",") {
+					c := strings.TrimSpace(part)
+					if c == "" || seen[c] {
+						continue
+					}
+					seen[c] = true
+					var cid int64
+					err := a.DB.QueryRow(`SELECT id FROM categories WHERE name=?`, c).Scan(&cid)
+					if errors.Is(err, sql.ErrNoRows) {
+						res, err := a.DB.Exec(`INSERT INTO categories(name) VALUES(?)`, c)
+						if err == nil {
+							cid, _ = res.LastInsertId()
+						}
+					}
+					if cid != 0 {
+						a.DB.Exec(`INSERT OR IGNORE INTO post_categories(post_id, category_id) VALUES(?,?)`, pid, cid)
+					}
+				}
+			}
+		}
+		http.Redirect(w, r, "/post?id="+strconv.FormatInt(pid, 10), http.StatusSeeOther)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+/*
+HandleShowPost displays a single post and its comments.
+*/
+func (a *App) HandleShowPost(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	type Post struct {
+		ID                    int64
+		Title, Body, Username string
+		CreatedAt             string
+		Likes, Dislikes       int
+		Categories            []string
+	}
+	var p Post
+	var ts time.Time
+	err := a.DB.QueryRow(`SELECT p.id, p.title, p.body, p.created_at, u.username,
+        (SELECT COUNT(*) FROM likes l WHERE l.target_type='post' AND l.target_id=p.id AND l.value=1) AS likes,
+        (SELECT COUNT(*) FROM likes l WHERE l.target_type='post' AND l.target_id=p.id AND l.value=-1) AS dislikes
+        FROM posts p
+        JOIN users u ON u.id=p.user_id
+        WHERE p.id=?`, id).Scan(&p.ID, &p.Title, &p.Body, &ts, &p.Username, &p.Likes, &p.Dislikes)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	p.CreatedAt = ts.Format("2006-01-02 15:04")
+	rows, _ := a.DB.Query(`SELECT c.name FROM categories c JOIN post_categories pc ON pc.category_id=c.id WHERE pc.post_id=? ORDER BY c.name`, id)
+	defer rows.Close()
+	for rows.Next() {
+		var n string
+		rows.Scan(&n)
+		p.Categories = append(p.Categories, n)
+	}
+
+	crows, err := a.DB.Query(`SELECT c.id, c.body, c.created_at, u.username,
+        (SELECT COUNT(*) FROM likes l WHERE l.target_type='comment' AND l.target_id=c.id AND l.value=1) AS likes,
+        (SELECT COUNT(*) FROM likes l WHERE l.target_type='comment' AND l.target_id=c.id AND l.value=-1) AS dislikes
+        FROM comments c
+        JOIN users u ON u.id=c.user_id
+        WHERE c.post_id=?
+        ORDER BY c.created_at ASC`, id)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	type Comment struct {
+		ID                        int64
+		Body, Username, CreatedAt string
+		Likes, Dislikes           int
+	}
+	var comments []Comment
+	for crows.Next() {
+		var cmt Comment
+		var t time.Time
+		if err := crows.Scan(&cmt.ID, &cmt.Body, &t, &cmt.Username, &cmt.Likes, &cmt.Dislikes); err == nil {
+			cmt.CreatedAt = t.Format("2006-01-02 15:04")
+			comments = append(comments, cmt)
+		}
+	}
+	uid, uname, logged := a.CurrentUser(r)
+	a.render(w, "post_show.html", map[string]any{
+		"View":     "post_show",
+		"Post":     p,
+		"Comments": comments,
+		"LoggedIn": logged,
+		"UserID":   uid,
+		"Username": uname,
+	})
+}
+
+/*
+HandleNewComment adds a comment to an existing post.
+*/
+func (a *App) HandleNewComment(w http.ResponseWriter, r *http.Request) {
+	uid, _, ok := a.CurrentUser(r)
+	if !ok {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	postID := r.FormValue("post_id")
+	body := r.FormValue("body")
+	if body == "" {
+		http.Error(w, "empty comment", 400)
+		return
+	}
+	if _, err := a.DB.Exec(`INSERT INTO comments(post_id, user_id, body) VALUES(?,?,?)`, postID, uid, body); err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	http.Redirect(w, r, "/post?id="+postID, http.StatusSeeOther)
+}
+
+/*
+HandleLike records a like or dislike for a post or comment.
+*/
+func (a *App) HandleLike(w http.ResponseWriter, r *http.Request) {
+	uid, _, ok := a.CurrentUser(r)
+	if !ok {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	typ := r.FormValue("type")
+	tid := r.FormValue("id")
+	val := r.FormValue("value")
+	_, err := a.DB.Exec(`INSERT INTO likes(user_id, target_type, target_id, value) VALUES(?,?,?,?)
+                         ON CONFLICT(user_id, target_type, target_id) DO UPDATE SET value=excluded.value`, uid, typ, tid, val)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	if typ == "post" {
+		http.Redirect(w, r, "/post?id="+tid, http.StatusSeeOther)
+	} else {
+		http.Redirect(w, r, r.Referer(), http.StatusSeeOther)
+	}
+}


### PR DESCRIPTION
## Summary
- split server setup, templates, and middleware into dedicated files
- document code paths with multi-line comments
- add a simple Makefile with build and run targets
- further split app package into auth, post, index, and category files

## Testing
- `go build -v ./...` *(fails: hung after building github.com/mattn/go-sqlite3, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a73429a0a48333b031991671ddd98c