### PR TITLE
Fix template definitions

### DIFF
--- a/internal/web/templates/400.html
+++ b/internal/web/templates/400.html
@@ -1,10 +1,8 @@
-{{define "400.html"}}
-  {{template "layout.html" .}}
-  {{define "title"}}Bad Request{{end}}
-  {{define "content"}}
-    <div class="error-page">
-      <h1 class="error-code">400</h1>
-      <p>Sorry, the request could not be processed.</p>
-    </div>
-  {{end}}
+{{define "title"}}Bad Request{{end}}
+{{define "content"}}
+  <div class="error-page">
+    <h1 class="error-code">400</h1>
+    <p>Sorry, the request could not be processed.</p>
+  </div>
 {{end}}
+{{template "layout.html" .}}

--- a/internal/web/templates/404.html
+++ b/internal/web/templates/404.html
@@ -1,10 +1,8 @@
-{{define "404.html"}}
-  {{template "layout.html" .}}
-  {{define "title"}}Page Not Found{{end}}
-  {{define "content"}}
-    <div class="error-page">
-      <h1 class="error-code">404</h1>
-      <p>Sorry, the page you were looking for could not be found.</p>
-    </div>
-  {{end}}
+{{define "title"}}Page Not Found{{end}}
+{{define "content"}}
+  <div class="error-page">
+    <h1 class="error-code">404</h1>
+    <p>Sorry, the page you were looking for could not be found.</p>
+  </div>
 {{end}}
+{{template "layout.html" .}}

--- a/internal/web/templates/500.html
+++ b/internal/web/templates/500.html
@@ -1,10 +1,8 @@
-{{define "500.html"}}
-  {{template "layout.html" .}}
-  {{define "title"}}Server Error{{end}}
-  {{define "content"}}
-    <div class="error-page">
-      <h1 class="error-code">500</h1>
-      <p>Oops! Something went wrong on our end.</p>
-    </div>
-  {{end}}
+{{define "title"}}Server Error{{end}}
+{{define "content"}}
+  <div class="error-page">
+    <h1 class="error-code">500</h1>
+    <p>Oops! Something went wrong on our end.</p>
+  </div>
 {{end}}
+{{template "layout.html" .}}

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -1,55 +1,53 @@
-{{define "index.html"}}
-  {{template "layout.html" .}}
-  {{define "title"}}Forum{{end}}
-  {{define "content"}}
-    <h1 class="page-title">Posts</h1>
-    <form class="filter-form" method="get" action="/">
-      <div class="filter-group">
-        <label for="category">Category:</label>
-        <select id="category" name="category">
-          <option value="">All</option>
-          {{range .Categories}}
-            <option value="{{.}}" {{if eq $.SelectedCategory .}}selected{{end}}>{{.}}</option>
-          {{end}}
-        </select>
-      </div>
-      {{if .LoggedIn}}
-      <div class="filter-group">
-        <label for="filter">Filter:</label>
-        <select id="filter" name="filter">
-          <option value="" {{if eq .SelectedFilter ""}}selected{{end}}>All posts</option>
-          <option value="mine" {{if eq .SelectedFilter "mine"}}selected{{end}}>My posts</option>
-          <option value="liked" {{if eq .SelectedFilter "liked"}}selected{{end}}>Liked posts</option>
-        </select>
-      </div>
-      {{end}}
-      <button type="submit" class="btn ml-2">Apply</button>
-    </form>
-    <div class="post-list">
-      {{range .Posts}}
-        <div class="card post-card">
-          <h2><a href="/post?id={{.ID}}">{{.Title}}</a></h2>
-          <div class="meta">by {{.Author}} on {{.CreatedAt.Format "02 Jan 2006 15:04"}}</div>
-          <p>{{.Body}}</p>
-          <div class="meta">Categories: {{.Categories}}</div>
-          <div class="reactions">
-            <form action="/like" method="get" class="inline-form">
-              <input type="hidden" name="type" value="post" />
-              <input type="hidden" name="id" value="{{.ID}}" />
-              <input type="hidden" name="value" value="1" />
-              <button type="submit" class="btn small {{if eq .MyReaction 1}}active{{end}}">👍 {{.LikeCount}}</button>
-            </form>
-            <form action="/like" method="get" class="inline-form ml-1">
-              <input type="hidden" name="type" value="post" />
-              <input type="hidden" name="id" value="{{.ID}}" />
-              <input type="hidden" name="value" value="-1" />
-              <button type="submit" class="btn small {{if eq .MyReaction -1}}active{{end}}">👎 {{.DislikeCount}}</button>
-            </form>
-          </div>
-        </div>
-      {{else}}
-        <p>No posts found.</p>
-      {{end}}
+{{define "title"}}Forum{{end}}
+{{define "content"}}
+  <h1 class="page-title">Posts</h1>
+  <form class="filter-form" method="get" action="/">
+    <div class="filter-group">
+      <label for="category">Category:</label>
+      <select id="category" name="category">
+        <option value="">All</option>
+        {{range .Categories}}
+          <option value="{{.}}" {{if eq $.SelectedCategory .}}selected{{end}}>{{.}}</option>
+        {{end}}
+      </select>
     </div>
-  {{end}}
+    {{if .LoggedIn}}
+    <div class="filter-group">
+      <label for="filter">Filter:</label>
+      <select id="filter" name="filter">
+        <option value="" {{if eq .SelectedFilter ""}}selected{{end}}>All posts</option>
+        <option value="mine" {{if eq .SelectedFilter "mine"}}selected{{end}}>My posts</option>
+        <option value="liked" {{if eq .SelectedFilter "liked"}}selected{{end}}>Liked posts</option>
+      </select>
+    </div>
+    {{end}}
+    <button type="submit" class="btn ml-2">Apply</button>
+  </form>
+  <div class="post-list">
+    {{range .Posts}}
+      <div class="card post-card">
+        <h2><a href="/post?id={{.ID}}">{{.Title}}</a></h2>
+        <div class="meta">by {{.Author}} on {{.CreatedAt.Format "02 Jan 2006 15:04"}}</div>
+        <p>{{.Body}}</p>
+        <div class="meta">Categories: {{.Categories}}</div>
+        <div class="reactions">
+          <form action="/like" method="get" class="inline-form">
+            <input type="hidden" name="type" value="post" />
+            <input type="hidden" name="id" value="{{.ID}}" />
+            <input type="hidden" name="value" value="1" />
+            <button type="submit" class="btn small {{if eq .MyReaction 1}}active{{end}}">👍 {{.LikeCount}}</button>
+          </form>
+          <form action="/like" method="get" class="inline-form ml-1">
+            <input type="hidden" name="type" value="post" />
+            <input type="hidden" name="id" value="{{.ID}}" />
+            <input type="hidden" name="value" value="-1" />
+            <button type="submit" class="btn small {{if eq .MyReaction -1}}active{{end}}">👎 {{.DislikeCount}}</button>
+          </form>
+        </div>
+      </div>
+    {{else}}
+      <p>No posts found.</p>
+    {{end}}
+  </div>
 {{end}}
+{{template "layout.html" .}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -13,7 +13,8 @@
         <a class="brand" href="/">Forum</a>
         {{if .LoggedIn}}
           <a href="/post/new" class="btn primary ml-2">New Post</a>
-        {{end}}
+  {{end}}
+
         <div class="spacer"></div>
         {{if .LoggedIn}}
           <span class="text-muted">Welcome, {{.Username}}</span>

--- a/internal/web/templates/login.html
+++ b/internal/web/templates/login.html
@@ -1,17 +1,15 @@
-{{define "login.html"}}
-  {{template "layout.html" .}}
-  {{define "title"}}Login{{end}}
-  {{define "content"}}
-    <h1>Login</h1>
-    {{if .Error}}
-      <p class="error">{{.Error}}</p>
-    {{end}}
-    <form method="post" action="/login" class="form">
-      <label>Email</label>
-      <input type="email" name="email" required />
-      <label>Password</label>
-      <input type="password" name="password" required />
-      <button type="submit" class="btn primary mt-2">Login</button>
-    </form>
+{{define "title"}}Login{{end}}
+{{define "content"}}
+  <h1>Login</h1>
+  {{if .Error}}
+    <p class="error">{{.Error}}</p>
   {{end}}
+  <form method="post" action="/login" class="form">
+    <label>Email</label>
+    <input type="email" name="email" required />
+    <label>Password</label>
+    <input type="password" name="password" required />
+    <button type="submit" class="btn primary mt-2">Login</button>
+  </form>
 {{end}}
+{{template "layout.html" .}}

--- a/internal/web/templates/post_new.html
+++ b/internal/web/templates/post_new.html
@@ -1,22 +1,20 @@
-{{define "post_new.html"}}
-  {{template "layout.html" .}}
-  {{define "title"}}New Post{{end}}
-  {{define "content"}}
-    <h1>New Post</h1>
-    <form method="post" action="/post/new" class="form">
-      <label>Title</label>
-      <input type="text" name="title" required />
-      <label>Body</label>
-      <textarea name="body" rows="8" required></textarea>
-      <fieldset>
-        <legend>Categories</legend>
-        {{range .Categories}}
-          <label class="checkbox-label">
-            <input type="checkbox" name="categories" value="{{.}}" /> {{.}}
-          </label>
-        {{end}}
-      </fieldset>
-      <button type="submit" class="btn primary mt-2">Publish</button>
-    </form>
-  {{end}}
+{{define "title"}}New Post{{end}}
+{{define "content"}}
+  <h1>New Post</h1>
+  <form method="post" action="/post/new" class="form">
+    <label>Title</label>
+    <input type="text" name="title" required />
+    <label>Body</label>
+    <textarea name="body" rows="8" required></textarea>
+    <fieldset>
+      <legend>Categories</legend>
+      {{range .Categories}}
+        <label class="checkbox-label">
+          <input type="checkbox" name="categories" value="{{.}}" /> {{.}}
+        </label>
+      {{end}}
+    </fieldset>
+    <button type="submit" class="btn primary mt-2">Publish</button>
+  </form>
 {{end}}
+{{template "layout.html" .}}

--- a/internal/web/templates/post_show.html
+++ b/internal/web/templates/post_show.html
@@ -1,62 +1,61 @@
-  {{template "layout.html" .}}
-  {{define "title"}}{{.Post.Title}}{{end}}
-  {{define "content"}}
-    <article class="post-detail">
-      <h1>{{.Post.Title}}</h1>
-      <div class="meta">by {{.Post.Author}} on {{.Post.CreatedAt.Format "02 Jan 2006 15:04"}}</div>
-      <p>{{.Post.Body}}</p>
-      <div class="meta">Categories: {{.Post.Categories}}</div>
-      <div class="reactions mt-1">
-        <form action="/like" method="get" class="inline-form">
-          <input type="hidden" name="type" value="post" />
-          <input type="hidden" name="id" value="{{.Post.ID}}" />
-          <input type="hidden" name="value" value="1" />
-          <button type="submit" class="btn small {{if eq .Post.MyReaction 1}}active{{end}}">👍 {{.Post.LikeCount}}</button>
-        </form>
-        <form action="/like" method="get" class="inline-form ml-1">
-          <input type="hidden" name="type" value="post" />
-          <input type="hidden" name="id" value="{{.Post.ID}}" />
-          <input type="hidden" name="value" value="-1" />
-          <button type="submit" class="btn small {{if eq .Post.MyReaction -1}}active{{end}}">👎 {{.Post.DislikeCount}}</button>
-        </form>
-      </div>
-    </article>
-    <section class="comments">
-      <h2>Comments ({{len .Post.Comments}})</h2>
-      {{range .Post.Comments}}
-        <div class="comment card">
-          <div class="meta">
-{{.Author}} at {{.CreatedAt.Format "02 Jan 2006 15:04"}}
-</div>
-          <p>{{.Body}}</p>
-          <div class="reactions">
-            <form action="/like" method="get" class="inline-form">
-              <input type="hidden" name="type" value="comment" />
-              <input type="hidden" name="id" value="{{.ID}}" />
-              <input type="hidden" name="post_id" value="{{$.Post.ID}}" />
-              <input type="hidden" name="value" value="1" />
-              <button type="submit" class="btn xsmall {{if eq .MyReaction 1}}active{{end}}">👍 {{.LikeCount}}</button>
-            </form>
-            <form action="/like" method="get" class="inline-form ml-1">
-              <input type="hidden" name="type" value="comment" />
-              <input type="hidden" name="id" value="{{.ID}}" />
-              <input type="hidden" name="post_id" value="{{$.Post.ID}}" />
-              <input type="hidden" name="value" value="-1" />
-              <button type="submit" class="btn xsmall {{if eq .MyReaction -1}}active{{end}}">👎 {{.DislikeCount}}</button>
-            </form>
-          </div>
+{{define "title"}}{{.Post.Title}}{{end}}
+{{define "content"}}
+  <article class="post-detail">
+    <h1>{{.Post.Title}}</h1>
+    <div class="meta">by {{.Post.Author}} on {{.Post.CreatedAt.Format "02 Jan 2006 15:04"}}</div>
+    <p>{{.Post.Body}}</p>
+    <div class="meta">Categories: {{.Post.Categories}}</div>
+    <div class="reactions mt-1">
+      <form action="/like" method="get" class="inline-form">
+        <input type="hidden" name="type" value="post" />
+        <input type="hidden" name="id" value="{{.Post.ID}}" />
+        <input type="hidden" name="value" value="1" />
+        <button type="submit" class="btn small {{if eq .Post.MyReaction 1}}active{{end}}">👍 {{.Post.LikeCount}}</button>
+      </form>
+      <form action="/like" method="get" class="inline-form ml-1">
+        <input type="hidden" name="type" value="post" />
+        <input type="hidden" name="id" value="{{.Post.ID}}" />
+        <input type="hidden" name="value" value="-1" />
+        <button type="submit" class="btn small {{if eq .Post.MyReaction -1}}active{{end}}">👎 {{.Post.DislikeCount}}</button>
+      </form>
+    </div>
+  </article>
+  <section class="comments">
+    <h2>Comments ({{len .Post.Comments}})</h2>
+    {{range .Post.Comments}}
+      <div class="comment card">
+        <div class="meta">{{.Author}} at {{.CreatedAt.Format "02 Jan 2006 15:04"}}</div>
+        <p>{{.Body}}</p>
+        <div class="reactions">
+          <form action="/like" method="get" class="inline-form">
+            <input type="hidden" name="type" value="comment" />
+            <input type="hidden" name="id" value="{{.ID}}" />
+            <input type="hidden" name="post_id" value="{{$.Post.ID}}" />
+            <input type="hidden" name="value" value="1" />
+            <button type="submit" class="btn xsmall {{if eq .MyReaction 1}}active{{end}}">👍 {{.LikeCount}}</button>
+          </form>
+          <form action="/like" method="get" class="inline-form ml-1">
+            <input type="hidden" name="type" value="comment" />
+            <input type="hidden" name="id" value="{{.ID}}" />
+            <input type="hidden" name="post_id" value="{{$.Post.ID}}" />
+            <input type="hidden" name="value" value="-1" />
+            <button type="submit" class="btn xsmall {{if eq .MyReaction -1}}active{{end}}">👎 {{.DislikeCount}}</button>
+          </form>
         </div>
-      {{else}}
-        <p>No comments yet.</p>
-      {{end}}
-      {{if .LoggedIn}}
-        <form action="/comment/new" method="post" class="form mt-3">
-          <input type="hidden" name="post_id" value="{{.Post.ID}}" />
-          <textarea name="body" rows="4" required placeholder="Your comment"></textarea>
-          <button type="submit" class="btn primary mt-1">Add comment</button>
-        </form>
-      {{else}}
-        <p><a href="/login">Log in</a> to comment.</p>
-      {{end}}
-    </section>
-  {{end}}
+      </div>
+    {{else}}
+      <p>No comments yet.</p>
+    {{end}}
+    {{if .LoggedIn}}
+      <form action="/comment/new" method="post" class="form mt-3">
+        <input type="hidden" name="post_id" value="{{.Post.ID}}" />
+        <textarea name="body" rows="4" required placeholder="Your comment"></textarea>
+        <button type="submit" class="btn primary mt-1">Add comment</button>
+      </form>
+    {{else}}
+      <p><a href="/login">Log in</a> to comment.</p>
+    {{end}}
+  </section>
+{{end}}
+{{template "layout.html" .}}
+

--- a/internal/web/templates/register.html
+++ b/internal/web/templates/register.html
@@ -1,19 +1,17 @@
-{{define "register.html"}}
-  {{template "layout.html" .}}
-  {{define "title"}}Register{{end}}
-  {{define "content"}}
-    <h1>Register</h1>
-    {{if .Error}}
-      <p class="error">{{.Error}}</p>
-    {{end}}
-    <form method="post" action="/register" class="form">
-      <label>Email</label>
-      <input type="email" name="email" required />
-      <label>Username</label>
-      <input type="text" name="username" required />
-      <label>Password</label>
-      <input type="password" name="password" required />
-      <button type="submit" class="btn primary mt-2">Create account</button>
-    </form>
+{{define "title"}}Register{{end}}
+{{define "content"}}
+  <h1>Register</h1>
+  {{if .Error}}
+    <p class="error">{{.Error}}</p>
   {{end}}
+  <form method="post" action="/register" class="form">
+    <label>Email</label>
+    <input type="email" name="email" required />
+    <label>Username</label>
+    <input type="text" name="username" required />
+    <label>Password</label>
+    <input type="password" name="password" required />
+    <button type="submit" class="btn primary mt-2">Create account</button>
+  </form>
 {{end}}
+{{template "layout.html" .}}


### PR DESCRIPTION
## Summary
- remove nested `define` blocks from HTML templates
- include the shared layout after defining `title` and `content`
- add missing newline to layout template

## Testing
- `go test ./...` *(fails: build stalls, terminated)*
- `make run` *(fails: build stalls, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4f9d1c108333a1f4cae9d8b0cef2